### PR TITLE
fix: Typo gopls config `usePlaceholder`

### DIFF
--- a/machines/t420/home/ditatompel/.config/nvim/lua/custom/configs/lspconfig.lua
+++ b/machines/t420/home/ditatompel/.config/nvim/lua/custom/configs/lspconfig.lua
@@ -23,7 +23,7 @@ lspconfig.gopls.setup {
     -- see https://github.com/golang/tools/tree/master/gopls
     gopls = {
       completeUnimported = true,
-      usePlaceholder = true,
+      usePlaceholders = true,
       analyses = {
         unusedparams = true,
       },


### PR DESCRIPTION
It should be `usePlaceholders` instead of `usePlaceholder`.